### PR TITLE
#description in snippets should be #pluginName

### DIFF
--- a/Nautilus/Nautilus.pillar
+++ b/Nautilus/Nautilus.pillar
@@ -88,12 +88,12 @@ You can also redefine the following method on the class side:
 And finally you can redefine the ==pluginName== method to change the name displayed in the Nautilus Plugin Manager.
 
 [[[
-MyPlugin class>>description
+MyPlugin class>>pluginName
 	^ 'MyPlugin'
 ]]]
 
 [[[
-MyPlugin class>>description
+MyPlugin class>>pluginName
 	^ 'A super cool plugin'
 ]]]
 


### PR DESCRIPTION
While correctly used in text, in the code snippets the method name appeared as `#description` in code snippers
