### PR TITLE
Pass on uFFI chapter

### DIFF
--- a/UnifiedFFI/UnifiedFFI.pillar
+++ b/UnifiedFFI/UnifiedFFI.pillar
@@ -57,86 +57,132 @@ As I've been pointed, the name is misleading, but it means "FFI with NB syntax".
 find a better name.
 SD: what is FFI-NB? UFFI?
 
-
 We now present how to use UnifiedFFI.
 
 !! Calling a simple external function
-
+A Foreign Function Interface (FFI) is the mechanism used by a programming language to invoke or call functions written in other programming language, most commonly ==C==.
+To illustrate what this means, and how uFFI achieves it, we will start with an example.
 Suppose that you want to know the amount of time the image has been running by calling the underlying OS function
-named ==clock==. This function is part of the standard C library (==libc==). Its C declaration is: According
-to man its return type is ==clock\_t== instead of ==uint==, but we deliberately made it ==uint== for the sake
-of simplicity. We will see how to deal with typedefs in the following sections.
+named ==clock==. This function is part of the standard C library (==libc==). Its C declaration is:
 
-SD: but can the user run it? Else this is not a tutorial.
+[[[
+clock_t clock(void);
+]]]
+
+For the sake of simplicity, let's consider that ==clock=='s return type is a ==unit== instead of ==clock\_t==.
+We will discuss about types, conversions and typedefs in the following sections.
+This would result in the following function signature.
 
 [[[
 uint clock (void)
 ]]]
 
-To call ==clock== from the image, you should write a binding: a normal Smalltalk method using the ==ffiCall:module:==
-message. Note that it exists other messages to define callouts. They will be discussed later.
-
-Here is the full definition of the binding of this ==clock== function:
-
-[[[language=smalltalk
-FFICExamples class >> ticksSinceStart
-  ^ self ffiCall: #( uint clock () ) module: LibC
-]]]
-
-In the above example, we define a method named ==ticksSinceStart== on the class side of the class named ==FFICExamples==.
-FFI-NB imposes no constraint on the class where the method should be added and programmers can choose to add their bindings  either on the instance- or the class-side.
-
-SD: do we have examples loadable?
-
-To know the number of native clock ticks since the Pharo Virtual Machine started, execute the method and print its result:
+To call ==clock== from the image, we need to define a binding between a Smalltalk method and the corresponding function.
+FFI bindings are normal smalltalk methods that use the ==ffiCall:module:== message to specify which function they will call.
+Let's then define a new class ==FFITutorial== and define in it a binding to the ==clock== function:
 
 [[[language=smalltalk
-FFICExamples ticksSinceStart
+Object subclass: #FFITutorial
+	instanceVariableNames: ''
+	classVariableNames: ''
+	package: 'FFITutorial'
+
+FFITutorial class >> ticksSinceStart
+  ^ self ffiCall: #( uint clock () ) module: 'libc.so.6'
 ]]]
 
-!!! Analysis of an FFI Callout
+Note that in this example we specify ==libc== as it exists in linux systems. For this code to run in other platforms you need to replace e.g., the =='libc.so.6'== string by =='libc.dylib'== in Mac OS or =='msvcrt.dll'== in windows.
 
-Now that the call worked, let us look at the definition again:
+For Mac OS:
+[[language=smalltalk
+FFITutorial class >> ticksSinceStart
+  ^ self ffiCall: #( uint clock () ) module: 'libc.dylib'
+]]]
+
+For Windows:
+[[language=smalltalk
+FFITutorial class >> ticksSinceStart
+  ^ self ffiCall: #( uint clock () ) module: 'msvcrt.dll'
+]]]
+
+In the example above, we define a new empty class, and a method named ==ticksSinceStart== on its class side.
+The method ==ffiCall:module:== is provided by UnifiedFFI and defined in ==Object==, so we can be use it either on the instance or the class-side.
+
+@@Warning the message ==#ffiCall:module:== cannot be used as a normal expression in a playground or in the middle of a method. It must only be sent by methods that define a callout, because it does some
+context mangling behind the scenes.
+
+To test if our code works, execute the method and print its result:
 
 [[[language=smalltalk
-FFICExamples class >> ticksSinceStart
-	^ self ffiCall: #( int clock () ) module: LibC
+FFITutorial ticksSinceStart
 ]]]
 
-!!!! Callout
+If everything went ok, this expression will return the number of native clock ticks since the Pharo proces started.
 
-What we have just done is usually named an FFI ''callout''.
-==#ffiCall:module:== is a method provided by the FFI-NB package and defined in the ==Object== class (so you can use it anywhere).
-It is responsible for generating an FFI callout.
-Calling a C function requires to marshall all arguments from Smalltalk to C, push them to the C stack, perform a call
-to the external function, and finally convert the return value from C to Smalltalk.
-Note that this message ==#ffiCall:module:== should only be sent by methods that define a callout, because it does some
-context handling behind the scenes.
+!!! Analyzing the FFI Callout
 
-==#ffiCall:module:== handles all of this using the description of the function you provided.
-Indeed, it has two arguments: the ''signature of the function'' that will be invoked and the ''module or library'' where
-to look for it.
-In this example we look for ==clock()== function in the standard C library.
+To understand what happenned and how it worked, let us look at the binding definition again:
 
-The signature is described by an array: here ==#(int clock ())==.
-- Its first element is the C return type, here ==int==.
+[[[language=smalltalk
+FFITutorial class >> ticksSinceStart
+	^ self ffiCall: #( uint clock () ) module: 'libc.so.6'
+]]]
+
+The binding we just did is also called an FFI callout, as it performs a call of a function in the ''outside world'' (the C world).
+The method ==ffiCall:module:== is the one in charge of making the callout.
+In other words, it first transforms (marshalls) all arguments from Smalltalk to C, pushes them to the C stack, performs a call
+to the external function, and finally converts (marshalls) the return value from C to Smalltalk.
+To do all this, ==ffiCall:module:== uses the function description provided as argument.
+The first argument is the ''signature'' of the function we want to call, described with an array, and the second argument is the ''module'' or ''library'' where
+uFFI will look for it.
+
+In our example, the signature is as follows: ==#(uint clock ())==
+- Its first element is the C return type, here ==uint==.
 - Its second is the name of the called function, here ==clock==.
-- Its third element is also an array which describes the function parameters if there's any.
+- Its third element is an array describing the function parameters if there's any.
 
-Basically, if you strip down the outer #(), what is inside is a C function prototype, which is very close to normal C syntax. This is intentionally done so, that in most cases you can actually copy-and-paste a complete C function declaration,  taken from header file or from documentation, and it is ready for use.
+Basically, if you strip down the outer #(), what is inside is a C function prototype, which is very close to normal C syntax.
+This is intentionally done so, that in most cases you can actually copy-and-paste a complete C function declaration,  taken from header file or from documentation, and it is ready for use.
+The second argument, the module or library, is in our example =='libc.so.6'==, the name of the library where to find the function.
+The avid reader will notice that our binding is platform dependent, as it will only run from a linux machine. We will explore how to define bindings in a platform-independent in the following section.
 
-The second argument, ==#module:==, should be a module name or a ==FFILibrary==. A module name is easy to explain: it is just  a string who points to your library, e.g. 'libc.so.6'. Libraries will be explained in next section.
+@@Guille is this next sentence necessary here?
+Note that there exist other messages to define callouts that will be discussed later.
 
-!!!! Using platform dependent libraries
+!! A Note on Marshaling
 
-In the previous example, you can see we used a reference to the class ==LibC== while specifying module, instead passing
-directly the string =='libc.so.6'==.
+In the ==clock== callout example above, we specified the return type as ==uint== and not ==SmallInteger==. You will see as you go on in the chapter that this is the same as
+well with function arguments. Types in bindings are all described in terms of C language. In general you don't have to worry too
+much about this, because uFFI knows how to map standard C values to Smalltalk objects and
+vice-versa. So, a callout is executed, the return value will be converted into a ==SmallInteger==.
+You can also define new mappings from C types to Smalltalk objects. This is useful when wrapping libraries that
+define new C types as we will show later.
 
-==LibC== inherits from ==FFILibrary== and is a very simple structure who allows you to solve dinamically (by platform) the
-real name of the library in the platform. In the case of ==LibC==, you will see it has (besides the misc methods), this methods
-defined.
+This conversion process for types from different languages is called ''marshalling''.
+We will see more examples of automatic conversions (by automatic, we mean that they are already defined in
+uFFI) in this Chapter.
+
+!! Modules and Libraries
+
+We saw before that a callout requires to specify a module or library.
+uFFI uses this information to look up the given function.
+In our previous example, we were looking up the ==clock== function inside the standard C library, i.e., ==libc.so.6== in my unix system.
+
+We saw until now how modules in uFFI can be expressed by using a library name.
+However, this has portability issues as a library will not have the same name in different platforms, or not be located in the same place.
+uFFI solves this problem by allowing also library objects.
+A library object defines dinamically the real name of the library in the current platform.
+A library in uFFI is defined as a subclass of ==FFILibrary== and defining the methods ==macModuleName==, ==unixModuleName== and ==win32ModuleName==.
+uFFI will dispatch to the library to get the correct module name given the current platform.
+
+Let's for example consider the library ==LibC== already provided by uFFI:
 
 [[[language=smalltalk
+FFILibrary subclass: #LibC
+	instanceVariableNames: ''
+	classVariableNames: ''
+	package: 'UnifiedFFI-Libraries'
+
 LibC>>macModuleName
 	^ 'libc.dylib'
 
@@ -148,8 +194,15 @@ LibC>>win32ModuleName
 	^ 'msvcrt.dll'
 ]]]
 
-As you can see is very easy to express different paths and names, depending on different conditions. For example, here you
-can see the definition of Cairo library in unix platforms:
+With this platform aware library implementation, we can re-implement our binding in a platform-independent fashion:
+
+[[[language=smalltalk
+FFITutorial class >> ticksSinceStart
+	^ self ffiCall: #( uint clock () ) module: LibC
+]]]
+
+As you can see, it is very easy to express different paths and names, depending on different conditions. For example, here you
+can see how the Cairo library is defined for unix platforms:
 
 [[[language=smalltalk
 CairoLibrary>>unixModuleName
@@ -166,33 +219,20 @@ CairoLibrary>>unixModuleName
 		self error: 'Cannot locate cairo library. Please check if it installed on your system'
 ]]]
 
-This is very useful and a recommended way of dealing with libraries (better than hardcoding module names).
+This is very useful and a recommended way of dealing with libraries, better than hardcoding module names.
 
-""Note"" that you can also define a method ==ffiModuleName== in the class your are implementing your bindings,
-for example:
+Finally, note that any class can also define a method ==ffiModuleName== to provide a default module for bindings in that class.
+Callouts may not specify a module to use this default module.
 
 [[[language=smalltalk
-FFICFunction class>>ffiLibraryName
+FFITutorial class>>ffiLibraryName
 	^ LibC
 
-FFICExamples class>>ticksSinceStart
+FFITutorial class>>ticksSinceStart
 	^ self ffiCall: #( uint clock () )
 ]]]
 
 @@note ==ffiLibraryName== is a terrible name I forget to change. It should be just ==ffiLibrary== (but now change is not so easy...)
-
-!!! About marshaling
-
-In the ==clock== callout example above, the return type is ==int== and not ==SmallInteger==. This is the same as
-with function arguments. They are all described in terms of C language. In general you don't have to worry too
-much about this, because the FFI-NB library knows how to map standard C values to Smalltalk objects and
-vice-versa. So, when this message is executed, the return value will be converted into a ==SmallInteger==.
-You can also define new mappings from C types to Smalltalk objects. This is useful when wrapping libraries that
-define new C types as we will show later.
-
-This conversion process for types from different languages is called ''marshalling''.
-We will see more examples of automatic conversions(By automatic, we mean that they are already defined in
-the FFI-NB library) in this Chapter.
 
 !! Passing arguments to a function
 

--- a/UnifiedFFI/UnifiedFFI.pillar
+++ b/UnifiedFFI/UnifiedFFI.pillar
@@ -8,6 +8,9 @@ UFFI has been developed by E. Lorenzano.
 
 
 !! uFFI Genesis
+
+@@todo Guille Is it really needed the historical part? Besides, the "content" part of this section is repeated in the rest of the document... Feels a bit irrelevant.
+
 As you know, in Pharo 5.0 we removed the previous FFI standard implementation called NativeBoost. This was made because different reasons:
 
 - First, we lost the main maintainer of NativeBoost/ASMJIT in a very critical moment, when we were migrating to the new Virtual Machine (Spur), which changed the object format forcing us to adapt NativeBoost (a non trivial task for non assembly-programming experts).

--- a/UnifiedFFI/UnifiedFFI.pillar
+++ b/UnifiedFFI/UnifiedFFI.pillar
@@ -1,39 +1,39 @@
 { "title": "UnifiedFFI" }
 
 Foreign Function Interface (FFI) represents the way to call functions/procedures and data structures written in C.
-In this document you will learn about the new FFI framework named uFFI. u stands for unified. 
+In this document you will learn about the new FFI framework named Unified FFI, or shortly, uFFI.
 We will present how to invoke functions written in C, access C struct, define callbacks and other frequent situations
 that you face when you want to interact with an external library.
-UFFI has been developed by E. Lorenzano. 
+UFFI has been developed by E. Lorenzano.
 
 
 !! uFFI Genesis
-As you know, in Pharo 5.0 we removed the previous FFI standard implementation called NativeBoost. This was made because different reasons: 
+As you know, in Pharo 5.0 we removed the previous FFI standard implementation called NativeBoost. This was made because different reasons:
 
 - First, we lost the main maintainer of NativeBoost/ASMJIT in a very critical moment, when we were migrating to the new Virtual Machine (Spur), which changed the object format forcing us to adapt NativeBoost (a non trivial task for non assembly-programming experts).
-- Second, we are in the process of add different platforms in which Pharo can run. 64bits being the most important, but also different ARMs. Using a assembly-oriented solution means that we have to develop a new back-end for each new architecture. 
+- Second, we are in the process of add different platforms in which Pharo can run. 64bits being the most important, but also different ARMs. Using a assembly-oriented solution means that we have to develop a new back-end for each new architecture.
 - Third, there were always concerns about safety and security when using NativeBoost (as you might know, it requires making executable the whole memory of Pharo).
-- Finally, our maintenance capacity is limited, and we wanted to unify the three  FFI backends FFI, Alien, and NativeBoost-ASMJIT into a single one. 
+- Finally, our maintenance capacity is limited, and we wanted to unify the three  FFI backends FFI, Alien, and NativeBoost-ASMJIT into a single one.
 
-So, when considering all these options, we arrived to the conclusion that we need to replace NativeBoost-ASMJIT with something we can maintain in the future. Since FFI and Alien will be merged into one FFI (to probably be migrated in the future to an enhanced version), and since there some people maintaining it besides us, the answer was obvious. 
+So, when considering all these options, we arrived to the conclusion that we need to replace NativeBoost-ASMJIT with something we can maintain in the future. Since FFI and Alien will be merged into one FFI (to probably be migrated in the future to an enhanced version), and since there some people maintaining it besides us, the answer was obvious.
 
-But we faced a problem: there is already a lot of libraries developed using NativeBoost-ASMJIT, and we do not want to lose 
-them (Athens and SDL2, for example, are core parts of Pharo and there are a lot more). 
+But we faced a problem: there is already a lot of libraries developed using NativeBoost-ASMJIT, and we do not want to lose
+them (Athens and SDL2, for example, are core parts of Pharo and there are a lot more).
 
-Also, we believe NativeBoost syntax and its effort for being close to C syntax are a big enhancement. It is a lot easier to work with a framework when you can take a header file and just copy a declaration. 
+Also, we believe NativeBoost syntax and its effort for being close to C syntax are a big enhancement. It is a lot easier to work with a framework when you can take a header file and just copy a declaration.
 
-Take this as an example: 
+Take this as an example:
 
 [[[language=smalltalk
 AthensCairoMatrix >> primMultiplyBy: m
 	self ffiCall: #(void cairo_matrix_multiply (
-		AthensCairoMatrix * self, 
-		AthensCairoMatrix * m , 
-		AthensCairoMatrix * self ) ) 
+		AthensCairoMatrix * self,
+		AthensCairoMatrix * m ,
+		AthensCairoMatrix * self ) )
 ]]]
 
-With the NativeBoost syntax is a lot simpler than to produce a primitive. 
-In addition the necessary bindings are simple too as shown below: 
+With the NativeBoost syntax is a lot simpler than to produce a primitive.
+In addition the necessary bindings are simple too as shown below:
 
 [[[language=smalltalk
 AthensCairoMatrix >> multiplyBy: m
@@ -45,12 +45,12 @@ AthensCairoMatrix >> primMultiplyBy: m
 ]]]
 
 SD: why do we have cdecl:?
-And of course things start to get complicated when you have to do more complex operations. 
+And of course things start to get complicated when you have to do more complex operations.
 
-In summary, we wanted to keep the NativeBoost syntax not just because of backward compatibility, but because we believe is a better approach to make C bindings than what we traditionally had. 
+In summary, we wanted to keep the NativeBoost syntax not just because of backward compatibility, but because we believe is a better approach to make C bindings than what we traditionally had.
 
-Then, we needed a way to use NativeBoost syntax with a different backend, and that's what the new FFI-NB does. 
-As I've been pointed, the name is misleading, but it means "FFI with NB syntax"... and yes, I agree we can 
+Then, we needed a way to use NativeBoost syntax with a different backend, and that's what the new FFI-NB does.
+As I've been pointed, the name is misleading, but it means "FFI with NB syntax"... and yes, I agree we can
 find a better name.
 SD: what is FFI-NB? UFFI?
 
@@ -59,9 +59,9 @@ We know present how to use UnifiedFFI.
 
 !! Calling a simple external function
 
-Suppose that you want to know the amount of time the image has been running by calling the underlying OS function 
-named ==clock==. This function is part of the standard C library (==libc==). Its C declaration is: According 
-to man its return type is ==clock\_t== instead of ==uint==, but we deliberately made it ==uint== for the sake 
+Suppose that you want to know the amount of time the image has been running by calling the underlying OS function
+named ==clock==. This function is part of the standard C library (==libc==). Its C declaration is: According
+to man its return type is ==clock\_t== instead of ==uint==, but we deliberately made it ==uint== for the sake
 of simplicity. We will see how to deal with typedefs in the following sections.
 
 SD: but can the user run it? Else this is not a tutorial.
@@ -70,8 +70,8 @@ SD: but can the user run it? Else this is not a tutorial.
 uint clock (void)
 ]]]
 
-To call ==clock== from the image, you should write a binding: a normal Smalltalk method using the ==ffiCall:module:== 
-message. Note that it exists other messages to define callouts. They will be discussed later. 
+To call ==clock== from the image, you should write a binding: a normal Smalltalk method using the ==ffiCall:module:==
+message. Note that it exists other messages to define callouts. They will be discussed later.
 
 Here is the full definition of the binding of this ==clock== function:
 
@@ -102,18 +102,18 @@ FFICExamples class >> ticksSinceStart
 
 !!!! Callout
 
-What we have just done is usually named an FFI ''callout''. 
-==#ffiCall:module:== is a method provided by the FFI-NB package and defined in the ==Object== class (so you can use it anywhere). 
+What we have just done is usually named an FFI ''callout''.
+==#ffiCall:module:== is a method provided by the FFI-NB package and defined in the ==Object== class (so you can use it anywhere).
 It is responsible for generating an FFI callout.
-Calling a C function requires to marshall all arguments from Smalltalk to C, push them to the C stack, perform a call 
-to the external function, and finally convert the return value from C to Smalltalk. 
-Note that this message ==#ffiCall:module:== should only be sent by methods that define a callout, because it does some 
-context handling behind the scenes. 
+Calling a C function requires to marshall all arguments from Smalltalk to C, push them to the C stack, perform a call
+to the external function, and finally convert the return value from C to Smalltalk.
+Note that this message ==#ffiCall:module:== should only be sent by methods that define a callout, because it does some
+context handling behind the scenes.
 
 ==#ffiCall:module:== handles all of this using the description of the function you provided.
-Indeed, it has two arguments: the ''signature of the function'' that will be invoked and the ''module or library'' where 
-to look for it.  
-In this example we look for ==clock()== function in the standard C library. 
+Indeed, it has two arguments: the ''signature of the function'' that will be invoked and the ''module or library'' where
+to look for it.
+In this example we look for ==clock()== function in the standard C library.
 
 The signature is described by an array: here ==#(int clock ())==.
 - Its first element is the C return type, here ==int==.
@@ -127,46 +127,46 @@ The second argument, ==#module:==, should be a module name or a ==FFILibrary==. 
 !!!! Using platform dependent libraries
 
 In the previous example, you can see we used a reference to the class ==LibC== while specifying module, instead passing
-directly the string =='libc.so.6'==. 
+directly the string =='libc.so.6'==.
 
-==LibC== inherits from ==FFILibrary== and is a very simple structure who allows you to solve dinamically (by platform) the 
+==LibC== inherits from ==FFILibrary== and is a very simple structure who allows you to solve dinamically (by platform) the
 real name of the library in the platform. In the case of ==LibC==, you will see it has (besides the misc methods), this methods
 defined.
 
 [[[language=smalltalk
 LibC>>macModuleName
 	^ 'libc.dylib'
-	
+
 LibC>>unixModuleName
 	^ 'libc.so.6'
-	
+
 LibC>>win32ModuleName
 	"While this is not a 'libc' properly, msvcrt has the functions we are defining here"
-	^ 'msvcrt.dll'	
+	^ 'msvcrt.dll'
 ]]]
 
-As you can see is very easy to express different paths and names, depending on different conditions. For example, here you 
-can see the definition of Cairo library in unix platforms: 
+As you can see is very easy to express different paths and names, depending on different conditions. For example, here you
+can see the definition of Cairo library in unix platforms:
 
 [[[language=smalltalk
 CairoLibrary>>unixModuleName
 		"On different flavors of linux the path to library may differ
 		depending on OS distro or whether system is 32 or 64 bit."
-	
-		#( 
+
+		#(
 			'/usr/lib/i386-linux-gnu/libcairo.so.2'
 			'/usr/lib32/libcairo.so.2'
-			'/usr/lib/libcairo.so.2') 
-		do: [ :path | 
+			'/usr/lib/libcairo.so.2')
+		do: [ :path |
 			path asFileReference exists ifTrue: [ ^ path ] ].
-	
+
 		self error: 'Cannot locate cairo library. Please check if it installed on your system'
 ]]]
 
-This is very useful and a recommended way of dealing with libraries (better than hardcoding module names). 
+This is very useful and a recommended way of dealing with libraries (better than hardcoding module names).
 
-""Note"" that you can also define a method ==ffiModuleName== in the class your are implementing your bindings, 
-for example: 
+""Note"" that you can also define a method ==ffiModuleName== in the class your are implementing your bindings,
+for example:
 
 [[[language=smalltalk
 FFICFunction class>>ffiLibraryName
@@ -180,21 +180,21 @@ FFICExamples class>>ticksSinceStart
 
 !!! About marshaling
 
-In the ==clock== callout example above, the return type is ==int== and not ==SmallInteger==. This is the same as 
-with function arguments. They are all described in terms of C language. In general you don't have to worry too 
-much about this, because the FFI-NB library knows how to map standard C values to Smalltalk objects and 
-vice-versa. So, when this message is executed, the return value will be converted into a ==SmallInteger==. 
-You can also define new mappings from C types to Smalltalk objects. This is useful when wrapping libraries that 
-define new C types as we will show later. 
+In the ==clock== callout example above, the return type is ==int== and not ==SmallInteger==. This is the same as
+with function arguments. They are all described in terms of C language. In general you don't have to worry too
+much about this, because the FFI-NB library knows how to map standard C values to Smalltalk objects and
+vice-versa. So, when this message is executed, the return value will be converted into a ==SmallInteger==.
+You can also define new mappings from C types to Smalltalk objects. This is useful when wrapping libraries that
+define new C types as we will show later.
 
-This conversion process for types from different languages is called ''marshalling''. 
-We will see more examples of automatic conversions(By automatic, we mean that they are already defined in 
-the FFI-NB library) in this Chapter. 
+This conversion process for types from different languages is called ''marshalling''.
+We will see more examples of automatic conversions(By automatic, we mean that they are already defined in
+the FFI-NB library) in this Chapter.
 
 !! Passing arguments to a function
 
-The previous ==clock== example was the one of the simplest possible. It executes a function without parameters and we 
-got the result. Now let's look how we can call functions that take arguments. 
+The previous ==clock== example was the one of the simplest possible. It executes a function without parameters and we
+got the result. Now let's look how we can call functions that take arguments.
 
 !!! Passing a method parameter
 
@@ -211,15 +211,15 @@ FFICExamples class>>abs: anInteger
 	^ self ffiCall: #( int abs (int anInteger) ) module: LibC
 ]]]
 
-Compared to the previous example, we changed the name of the function and added an argument. 
+Compared to the previous example, we changed the name of the function and added an argument.
 When functions have arguments you have to specify two things for each of them:
-# their type and the object that you want to be sent to the C function. That is, in the arguments array, we put the type of the argument (==int== in this example), and 
-# the ''name of the Smalltalk variable'' we pass as argument. 
+# their type and the object that you want to be sent to the C function. That is, in the arguments array, we put the type of the argument (==int== in this example), and
+# the ''name of the Smalltalk variable'' we pass as argument.
 
-Here ==anInteger== in ==#(int abs (int anInteger)== means that the variable is bound to the ==abs:== method parameter 
-and will be converted to a C int, when executing a call. 
+Here ==anInteger== in ==#(int abs (int anInteger)== means that the variable is bound to the ==abs:== method parameter
+and will be converted to a C int, when executing a call.
 
-This type-and-name pairs will be repeated, separated by comma for each argument, as we will show in the next examples. 
+This type-and-name pairs will be repeated, separated by comma for each argument, as we will show in the next examples.
 
 Now you can try printing this:
 
@@ -229,19 +229,19 @@ FFICExamples abs: -42.
 
 !!! About arguments
 
-In the callout code/binding declaration, we are expressing not one but ''two'' different aspects: the obvious one 
-is the C function signature, the other one is the objects to pass as arguments to the C function when the method is 
-invoked. 
-In this second aspect there are many possibilities. 
+In the callout code/binding declaration, we are expressing not one but ''two'' different aspects: the obvious one
+is the C function signature, the other one is the objects to pass as arguments to the C function when the method is
+invoked.
+In this second aspect there are many possibilities.
 In our example the argument of the C function is the method argument: ==anInteger==.
 But it is not always necessary the case.
-You can also use some constants, and in that case it's not always necessary to specify the type of the argument. 
-This is because FFI-NB automatically uses them as C 'int's: ==nil== and ==false== are converted to 0, and ==true== to 1. 
-Numbers are converted to their respective value, and can be positive and negative. 
+You can also use some constants, and in that case it's not always necessary to specify the type of the argument.
+This is because FFI-NB automatically uses them as C 'int's: ==nil== and ==false== are converted to 0, and ==true== to 1.
+Numbers are converted to their respective value, and can be positive and negative.
 
 !!! Passing literals
 
-Imagine that we want to have a wrapper that always calls the ==abs== function with the number -42. 
+Imagine that we want to have a wrapper that always calls the ==abs== function with the number -42.
 Then we directly define it as follows:
 
 [[[language=smalltalk
@@ -249,7 +249,7 @@ FFICExamples class>>absMinusFortyTwo
 	^ self ffiCall: #( int abs (-42) ) module: LibC
 ]]]
 
-Note that we omitted the type of the argument and directly write  ==int abs (-45)== instead of writing 
+Note that we omitted the type of the argument and directly write  ==int abs (-45)== instead of writing
 ==int abs (int -45)== since by default arguments are automatically converted to C int.
 
 But, if the C function takes a float/double as argument for example, you must specify it in the signature:
@@ -266,7 +266,7 @@ FFICExamples class>>floor: aFloat
 Often some functions in C libraries take flags as arguments whose values are declared using #define in C headers.
 You can, of course take these constant values from header and put them into your callout.
 But it is preferable to use a symbolic names for constants, which is much less confusing than just bare numbers.
-To use a symbolic constant you can create an instance-variable, a class-variable or a variable in shared pool, and 
+To use a symbolic constant you can create an instance-variable, a class-variable or a variable in shared pool, and
 then use the variable name as an argument in your callout.
 
 For example, imagine that we always pass a constant value to our function that is stored in a class variable of our class:
@@ -292,7 +292,7 @@ FFICContantExamples class>>absMinusFortyTwo
 	^ self ffiCall: #( int abs ( TheAnswer ) ) module: LibC
 ]]]
 
-You can also pass ==self== or any instance variable as arguments to a C call. 
+You can also pass ==self== or any instance variable as arguments to a C call.
 Suppose you want to add the ==abs== function binding to the class ==SmallInteger== in a method named  ==absoluteValue==, so that we can execute ==-50 absoluteValue==.
 
 In that case we simply add the ==absoluteValue== method to ==SmallInteger==, and we directly pass ==self== as illustrated below.
@@ -306,17 +306,17 @@ It is is also possible to pass an instance variable, but we let you do it as an 
 
 !!! Passing strings
 
-As you may know strings in C are sequences of characters terminated with a special character: ==\\0==. 
-It is then interesting to see how FFI-NB deals with them since they are an important data structure in C. 
-For this, we will call the very well known ==strlen== function. 
-This function requires a string as argument and returns its number of characters. 
+As you may know strings in C are sequences of characters terminated with a special character: ==\\0==.
+It is then interesting to see how FFI-NB deals with them since they are an important data structure in C.
+For this, we will call the very well known ==strlen== function.
+This function requires a string as argument and returns its number of characters.
 
-""C header"". 
+""C header"".
 [[[
 int strlen ( const char * str );
 ]]]
 
-""Smalltalk binding"". 
+""Smalltalk binding"".
 [[[language=smalltalk
 FFICExamples class>>stringLength: aString
 	^ self ffiCall: #( int strlen (String aString) ) module: LibC
@@ -324,15 +324,15 @@ FFICExamples class>>stringLength: aString
 
 !!!! Example analysis.
 
-You may have noticed that the callout description is not exactly the same as the C function header. 
+You may have noticed that the callout description is not exactly the same as the C function header.
 
-In the signature ==#( int strlen (String aString) )== there are two differences with the C signature. 
+In the signature ==#( int strlen (String aString) )== there are two differences with the C signature.
 - The first difference is the const keyword of the argument. For those not used to C, that's only a modifier keyword that the compiler takes into account to make some static validations at compile time. It has no value when describing the signature for calling a function at runtime.
 - The second difference, an important one, is the specification of the argument. It is declared as ==String aString== instead of ==char * aString==. With ==String aString==, FFI-NB will automatically do the arguments conversion from Smalltalk strings to C strings (null terminated). Therefore it is important to use String and not ==char *==. In the example, the string passed will be put in an external C ==char== array and a null termination character will be added to it. Also, this array will be automatically released after the call ends. This automatic memory management is very useful but we can also control it as we will see later. Using ==(String aString)== is equivalent to ==(someString copyWith: (Character value:0)== as in ==FFICExamples stringLength: (someString copyWith: (Character value:0)==. Conversely, FFI-NB will take the C result value of calling the C function and convert it to a proper Smalltalk Integer in this particular case.
 
 !!! Passing two strings
 
-We will now call the ==strcmp== function, which takes two strings as arguments and returns -1, 0 or 1 depending on 
+We will now call the ==strcmp== function, which takes two strings as arguments and returns -1, 0 or 1 depending on
 the relationship between both strings.
 
 ""C header""
@@ -342,17 +342,17 @@ the relationship between both strings.
 
 ""Smalltalk binding""
 [[[language=smalltalk
-FFICExamples class>>stringCompare: aString with: anotherString 
+FFICExamples class>>stringCompare: aString with: anotherString
 	^ self ffiCall: #( int strcmp (String aString, String anotherString) ) module: LibC
 ]]]
 
-Notice that you can add arguments by appending them to the arguments array, using a comma to separate them. Also 
+Notice that you can add arguments by appending them to the arguments array, using a comma to separate them. Also
 notice that you have to explicitly tell which object is going to be sent for each argument, as already told. In this
 case, aString is the first one and anotherString is the second one.
 
 !! Getting return value from a function
 
-Symmetrically to arguments, returned values are also marshalled, it means that C values are converted to Smalltalk objects. 
+Symmetrically to arguments, returned values are also marshalled, it means that C values are converted to Smalltalk objects.
 
 We already saw that implicitly through multiple examples since the beginning of the chapter.
 For example in the ==abs== example, the result is converted from an int to a SmallInteger.
@@ -365,26 +365,26 @@ FFICExamples>>#getEnv: aString
 	^ self ffiCall: #( String getenv (String string) ) module: LibC
 ]]]
 
-There is a mapping defined for each atomic type. About a bit more complex objects (like external objects or structures), 
+There is a mapping defined for each atomic type. About a bit more complex objects (like external objects or structures),
 we will talk in following sections.
 
 !!! Returning "void *"
 
-Take this call as an example: 
+Take this call as an example:
 
 [[[language=smalltalk
 FFICExamples class>>malloc: aNumber
 	^ self ffiCall: #( void * malloc ( int aNumber ) )
 ]]]
 
-This is a special case of return: when there is a function who answers a ''void *''. In this case, since FFI-NB cannot know 
+This is a special case of return: when there is a function who answers a ''void *''. In this case, since FFI-NB cannot know
 which kind of object it represents, it will answer an instance of ==ExternalData== (we will see this in next section).
 
 @@todo Luc illustrate that when NULL (a pointer with value 0) is returned, it is automatically converted to nil
 
 !! External address
 
-External addresses (contained in the class ==ExternalAddress==) is the way we represent any kind of data ''outside'' 
+External addresses (contained in the class ==ExternalAddress==) is the way we represent any kind of data ''outside''
 Smalltalk. That means data (pointers, structures, arrays) who are allocated in the heap.
 
 An ==ExternalAddress== can be:
@@ -392,25 +392,25 @@ An ==ExternalAddress== can be:
 - an allocation of memory (you can use ==ExternalAddress class>>allocate:== or ==ExternalAddress class>>gcallocate:==). Note that in case of ==#allocate:== you will need to ==#free== the external address later (==#gcallocate:== does that work for you).
 - the result of a function call (usually it will come as part of an ==ExternalData==)
 
-==ExternalData== represents an ==ExternalAddress== with an C type associated. For example, 
+==ExternalData== represents an ==ExternalAddress== with an C type associated. For example,
 
-Both ==ExternalAddress== and ==ExternalData== can be used as arguments when declaring functions with pointers as parameters, 
+Both ==ExternalAddress== and ==ExternalData== can be used as arguments when declaring functions with pointers as parameters,
 for example:
 
 [[[
 LibC>>memCopy: src to: dest size: n
 	^ self ffiCall: #(void *memcpy(void *dest, const void *src, size_t n)
 ]]]
- 
+
 !! External objects
 
-FFIExternalObject represent an object in the heap. An external object is a reference to any kind of data allocated 
-in the heap mapped to a Smalltalk object. 
+FFIExternalObject represent an object in the heap. An external object is a reference to any kind of data allocated
+in the heap mapped to a Smalltalk object.
 
 This is confusing, so I will try to explain it better: When you allocate a region of memory in the heap, you get a pointer
-to that location, which does not represent anything. But often, frameworks will allocate structures, pointers, etc. which 
-actually represents "an object" (not in the same sense as a Smalltalk object, but can be interpreted like one). For example, 
-to create a cairo surface, you can call this: 
+to that location, which does not represent anything. But often, frameworks will allocate structures, pointers, etc. which
+actually represents "an object" (not in the same sense as a Smalltalk object, but can be interpreted like one). For example,
+to create a cairo surface, you can call this:
 
 [[[
 AthensCairoSurface class>>primImage: aFormat width: aWidth height: aHeight
@@ -419,10 +419,10 @@ AthensCairoSurface class>>primImage: aFormat width: aWidth height: aHeight
                                                                       int aHeight) )
 ]]]
 
-This will call the cairo function ==cairo_image_surface_create== but instead answer an ==ExternalAddress== it will create an 
+This will call the cairo function ==cairo_image_surface_create== but instead answer an ==ExternalAddress== it will create an
 instance of ==AthensCairoSurface==, so you can treat the allocated pointer as an object.
 
-Any class in the system can be an external object as long as either: 
+Any class in the system can be an external object as long as either:
 
 - it inherits from ==FFIExternalObject==; or
 - it implements in its ""class side"" the method ==asExternalTypeOn:==.
@@ -435,30 +435,30 @@ AthensCairoCanvas class>>asExternalTypeOn: generator
 		^ FFIExternalObjectType objectClass: self
 ]]]
 
-@@note if you want to add the resource to an automatic free mechanism (to make GC frees also the external object), you need 
-to call ==autoRelease== (in case of children from FFIExternalObject) or implement similar mechanism. 
+@@note if you want to add the resource to an automatic free mechanism (to make GC frees also the external object), you need
+to call ==autoRelease== (in case of children from FFIExternalObject) or implement similar mechanism.
 
 @@note FFIExternalObject replaces NBExternalObject
 
 !!! How #autoRelease works
 
-Sending #autoRelease message of an object registers object for finalisation with a particular executor. 
-Then behaviour is divided: 
+Sending #autoRelease message of an object registers object for finalisation with a particular executor.
+Then behaviour is divided:
 
 A.1) for ExternalAddresses, it just registers in regular way, who will call #finalize on GC
 A.2) finalize will just call a free assuming ExternalAddress was allocated (which is a malloc)
 
 B.1) for all FFIExternalReference, it will register for finalisation what #resourceData answers (normally, the handle of the object)
 B.2) finalisation process will call the object class>>#finalizeResourceData: method, with the #resourceData result as parameter
-B.3) each kind of external reference can decide how to free that data (by default is also just freeing). 
+B.3) each kind of external reference can decide how to free that data (by default is also just freeing).
 
-An example of this is how AthensCairoSurface works. 
+An example of this is how AthensCairoSurface works.
 
 @todo add an example
 
 !! Structures
-The ==FFIExternalStructure== object is used to manipulate C structures from Pharo.  
-From the standard C library we can use the div() function as an example. 
+The ==FFIExternalStructure== object is used to manipulate C structures from Pharo.
+From the standard C library we can use the div() function as an example.
 Given a numerator and denominator, it returns a structure holding the quotient and remainder.
 In stdlib.h we find these definitions...
 
@@ -519,7 +519,7 @@ MyStructure class>>#fieldsDesc
     uint8 id;
     char * struct_name;
     uint name_length;
-    ) 
+    )
 ]]]
 
 Once the structure is described, you can generate the accessors by evaluating ==MyStructure rebuildFieldAccessors==.
@@ -594,18 +594,18 @@ myStruct structName. "bar"
 
 !! Deprecated/modified/not working
 
-- ==nbCall:...== methods are replaced by ==ffiCall:...== methods. While ==nbCall:...== still work, they will be deprecated in future versions. 
-- ==nbLibraryNameOrHandle== is replaced by ==ffiLibraryName==. It has to answer ""a string or a children of ==FFILibrary=="". 
+- ==nbCall:...== methods are replaced by ==ffiCall:...== methods. While ==nbCall:...== still work, they will be deprecated in future versions.
+- ==nbLibraryNameOrHandle== is replaced by ==ffiLibraryName==. It has to answer ""a string or a children of ==FFILibrary=="".
 - NB types has been replaced with FFI types (but they should work the same). But if you have direct references to ==NBInt32== (for example), you need to change it.
 
 !! Replacement for the NativeBoost class
 
 !! How does it works?
 
-In a very simplified way, old NativeBoost was taking the first calls to a method and transforming it 
+In a very simplified way, old NativeBoost was taking the first calls to a method and transforming it
 into machine code, then reexecuting the method who now jumps and executes the code stored in the method.
 
-To simplify, we do ""the same"" but instead injecting machine code, we create bytecodes to translate correctly input and output 
+To simplify, we do ""the same"" but instead injecting machine code, we create bytecodes to translate correctly input and output
 parameters, then we add a call to the function.
 
 @@todo here design explanation.
@@ -615,19 +615,17 @@ parameters, then we add a call to the function.
 
 
 !!! Non conventional casts
-Casting in C is trivial. You can do something like this: 
+Casting in C is trivial. You can do something like this:
 
 [[[
 void *var = 0x42000000.
 ]]]
 
-And you will be creating a pointer who points to the address 0x42000000. This kind of declarations are used 
+And you will be creating a pointer who points to the address 0x42000000. This kind of declarations are used
 in certain frameworks, notably some Windows libraries.
-In Pharo this "casting" is not so easy, and we need to declare this kind of variables as ExternalAddresses. We 
-do this as this: 
+In Pharo this "casting" is not so easy, and we need to declare this kind of variables as ExternalAddresses. We
+do this as this:
 
 [[[language=Smalltalk
 var := ExternalAddress fromAddress: 16r42000000.
 ]]]
-
-

--- a/UnifiedFFI/UnifiedFFI.pillar
+++ b/UnifiedFFI/UnifiedFFI.pillar
@@ -58,7 +58,7 @@ find a better name.
 SD: what is FFI-NB? UFFI?
 
 
-We know present how to use UnifiedFFI.
+We now present how to use UnifiedFFI.
 
 !! Calling a simple external function
 


### PR DESCRIPTION
Pass on section 1.2 mainly.
- Enhanced examples: unified types (was sometimes int, sometimes unit)
- Fixed typos and rewrote some paragraphs.
- Change the order of introduction of modules and libraries to have a better flow (first explain module names as strings, then introduce library objects to solve the problem of platform independent bindings)